### PR TITLE
[Backend] oauth 로그인시 쿼리파라미터 전달

### DIFF
--- a/backend/custom_auth/views.py
+++ b/backend/custom_auth/views.py
@@ -38,7 +38,7 @@ class Login42CallBack(APIView):
         user = oauth_42_serializer.get_or_create_user(oauth_42_serializer.validated_data)
         refresh = CustomTokenObtainPairSerializer.get_token(user)
 
-        redirect_url = 'http://localhost:3000'
+        redirect_url = 'http://localhost:3000?oauth=true'
         response = HttpResponseRedirect(redirect_url)
         set_cookie(response, refresh.access_token, "access_token")
         set_cookie(response, refresh, "refresh_token")


### PR DESCRIPTION
### 작업 내용
- oauth 로그인시 윈도우가 넘어가기 때문에 쿼리 파라미터를 전달해서 oauth 로그인이 진행되었음을 알려줍니다.