### PR TITLE
[Backend] backend jwt httponly 쿠키 방식으로 사용하는 것으로 커스텀

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/5.0/ref/settings/
 """
 
 import os
+from datetime import timedelta
 
 from pathlib import Path
 
@@ -243,4 +244,21 @@ SWAGGER_SETTINGS = {
             'description': 'Enter your Bearer token in the format **Bearer &lt;token>**'
         }
     }
+}
+
+SIMPLE_JWT = {
+    'ACCESS_TOKEN_LIFETIME': timedelta(days=1),
+    'ROTATE_REFRESH_TOKENS': False,
+    'BLACKLIST_AFTER_ROTATION': True,
+
+    'ALGORITHM': 'HS256',
+    'SIGNING_KEY': SECRET_KEY,
+    'VERIFYING_KEY': None,
+
+    'AUTH_HEADER_TYPES': ('Bearer',),
+    'AUTH_HEADER_NAME': 'HTTP_AUTHORIZATION',
+    'USER_ID_FIELD': 'id',
+    'USER_ID_CLAIM': 'user_id',
+
+    'AUTH_TOKEN_CLASSES': ('rest_framework_simplejwt.tokens.AccessToken',),
 }

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -53,6 +53,7 @@ MIDDLEWARE = [
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
+    'custom_auth.middleware.JWTAuthenticationMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -34,7 +34,6 @@ router.register(r'check', views.UserCheckViewSet, basename="user check")
 urlpatterns = [
     path('api/', include(router.urls)),
     path('api/login/default/', CustomTokenObtainPairView.as_view(), name='token_obtain_pair'),
-    path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path('admin/', admin.site.urls),
     path('api-auth/', include('rest_framework.urls', namespace='rest_framework')),
     path('docs/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),

--- a/backend/custom_auth/middleware.py
+++ b/backend/custom_auth/middleware.py
@@ -1,0 +1,10 @@
+class JWTAuthenticationMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        access_token = request.COOKIES.get('access_token')
+        if access_token:
+            request.META['HTTP_AUTHORIZATION'] = f'Bearer {access_token}'
+        response = self.get_response(request)
+        return response

--- a/backend/custom_auth/serializers.py
+++ b/backend/custom_auth/serializers.py
@@ -50,8 +50,6 @@ class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
 
 
 class TokenResponseSerializer(serializers.Serializer):
-    access = serializers.CharField(read_only=True)
-    refresh = serializers.CharField(read_only=True)
     mfa_require = serializers.BooleanField(read_only=True)
     user_id = serializers.IntegerField(read_only=True)
 

--- a/backend/custom_auth/views.py
+++ b/backend/custom_auth/views.py
@@ -103,11 +103,11 @@ class MFATokenGenerateView(APIView):
         user = request.user
         user.mfa_code_check(serializer.validated_data["mfa_code"])
         refresh = CustomTokenObtainPairSerializer.get_2fa_token(user)
-        return Response(
-            {'access': str(refresh.access_token),
-             'refresh': str(refresh),
-             'mfa_require': refresh['mfa_require'],
+        response = Response(
+            {'mfa_require': refresh['mfa_require'],
              'user_id': user.id}, status=201)
+        set_cookie(response, str(refresh.access_token), "access_token")
+        return response
 
 
 class MFAEnableView(APIView):
@@ -128,11 +128,11 @@ class MFAEnableView(APIView):
         user = request.user
         user.update_mfa_enable(serializer.validated_data["mfa_code"])
         refresh = CustomTokenObtainPairSerializer.get_2fa_token(user)
-        return Response(
-            {'access': str(refresh.access_token),
-             'refresh': str(refresh),
-             'mfa_require': refresh['mfa_require'],
+        response = Response(
+            {'mfa_require': refresh['mfa_require'],
              'user_id': user.id}, status=201)
+        set_cookie(response, str(refresh.access_token), "access_token")
+        return response
 
 
 class MFADisableView(APIView):

--- a/backend/custom_auth/views.py
+++ b/backend/custom_auth/views.py
@@ -57,7 +57,14 @@ class CustomTokenObtainPairView(TokenObtainPairView):
         request_body=CustomTokenObtainPairSerializer,
         responses={200: TokenResponseSerializer})
     def post(self, request, *args, **kwargs):
-        return super().post(request, *args, **kwargs)
+        super_response = super().post(request, *args, **kwargs)
+        if super_response.status_code == status.HTTP_200_OK:
+            response = Response(
+                {'mfa_require': super_response.data.get('mfa_require', None),
+                 'user_id': super_response.data.get('user_id', None)}, status=200)
+            set_cookie(response, super_response.data.get('access', None), "access_token")
+            return response
+        return super_response
 
 
 class MFACodeGenerateView(APIView):


### PR DESCRIPTION
## 작업 내용
- 로그인 및 기타 인증시 토큰 발급을 쿠키로 변경
- 프론트에서 httponly 쿠키를 보내주면 서버측에서 검증
- refresh 토큰 전략 폐기
- 쿠키를 헤더에 넣어주는 서버 미들웨어 개발