### PR TITLE
[Frontend] 일반 로그인 시 mfa 페이지 접근 안됨

### DIFF
--- a/frontend/src/api/auth/fetchSignIn.js
+++ b/frontend/src/api/auth/fetchSignIn.js
@@ -8,10 +8,8 @@ const fetchSignIn = (body) => {
   fetchAPI
     .post("/login/default/", body)
     .then((data) => {
-      sessionStorage.setItem("mfa_require", data.mfa_require);
-      sessionStorage.setItem("user_id", data.user_id);
       if (data.mfa_require) {
-        navigate("/mfa");
+        navigate(`/?mfa_require=true&user_id=${data.user_id}`);
       } else {
         fetchUserInfo(data.user_id);
         navigate("/");

--- a/frontend/src/api/auth/fetchSignInTwoFA.js
+++ b/frontend/src/api/auth/fetchSignInTwoFA.js
@@ -1,12 +1,16 @@
 import fetchAPI from "../../utils/fetchAPI.js";
 import getRouter from "../../core/router.js";
+import fetchUserInfo from "../user/fetchUserInfo.js";
 
 const fetchSignInTwoFA = (code) => {
   fetchAPI
     .post("/2fa/token/", {
       mfa_code: code,
     })
-    .then(() => getRouter().navigate("/"))
+    .then(() => {
+      fetchUserInfo(sessionStorage.getItem("user_id"));
+      getRouter().navigate("/");
+    })
     .catch(() => console.error("2fa verification on sign-in failed"));
 };
 

--- a/frontend/src/core/router.js
+++ b/frontend/src/core/router.js
@@ -8,11 +8,11 @@ const initRouter = () => {
     const handleRouteChange = () => {
       const path = window.location.pathname;
       const searchParams = new URLSearchParams(window.location.search);
+      const mfaRequire = searchParams.get("mfa_require");
 
       let createComponent = routesMemo[path];
 
-      if (path === "/" && searchParams.get("oauth") === "true") {
-        const mfaRequire = searchParams.get("mfa_require");
+      if (path === "/" && mfaRequire) {
         sessionStorage.setItem("mfa_require", mfaRequire);
         sessionStorage.setItem("user_id", searchParams.get("user_id"));
         if (mfaRequire === "true") {

--- a/frontend/src/pages/TwoFAPage.js
+++ b/frontend/src/pages/TwoFAPage.js
@@ -18,10 +18,10 @@ export default class TwoFAPage extends Component {
   }
 
   mounted() {
-    const $SignInContent = this.$target.querySelector("#signin-page-content");
+    const $signInContent = this.$target.querySelector("#signin-page-content");
 
-    const pageContainer = new PageContainer(this.$target, $SignInContent);
-    const twoFAForm = new TwoFAForm($SignInContent, { type: "signin" });
+    const pageContainer = new PageContainer(this.$target, $signInContent);
+    const twoFAForm = new TwoFAForm($signInContent, { type: "signin" });
 
     pageContainer.render();
     twoFAForm.render();


### PR DESCRIPTION
- 기존에 일반 로그인 시 직접 /mfa 경로로 이동시키던 것을 OAuth 시 mfa와 마찬가지로 루트 경로에 mfa_require 쿼리 파라미터를 전달하여 리다이렉트하도록 수정하였습니다.
- mfa 인증 완료 시 유저 정보를 요청하여 sessionStorage에 저장하도록 하였습니다.