### PR TITLE
[Frontend] component 렌더링 방식 수정

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -33,9 +33,11 @@ export default class App extends Component {
           }
         })
         .catch((e) => {
-          sessionStorage.clear();
-          navigate("/start");
-          showToast(e);
+          if (e.status && e.status === 401) {
+            sessionStorage.clear();
+            navigate("/start");
+            showToast(e);
+          }
         });
     };
 

--- a/frontend/src/components/Game/PlayerOverviews.js
+++ b/frontend/src/components/Game/PlayerOverviews.js
@@ -7,10 +7,14 @@ export default class PlayerOverviews extends Component {
     return `
       <div class="d-flex flex-column align-items-center m-4 text-white">
         ${type === "tournament" ? `<h4>${matchOrder}st match</h4>` : ""}
-        <div
-          id="player-overview-container-${matchOrder}"
+        <div 
+          id="player-${matchOrder}-overview-container"
           class="d-flex align-items-center"
-        ></div>
+        >
+          <div id="player-${matchOrder}-1-overview"></div>
+          <h2 class="text-white fw-bold mx-3">vs</h2>
+          <div id="player-${matchOrder}-2-overview"></div>
+        </div>
       </div>
     `;
   }
@@ -18,18 +22,19 @@ export default class PlayerOverviews extends Component {
   mounted() {
     const { matchOrder, player1, player2 } = this.props;
     const $container = this.$target.querySelector(
-      `#player-overview-container-${matchOrder}`
+      `#player-${matchOrder}-overview-container`
     );
-    const player1Overview = new PlayerOverview($container, player1);
-    const player2Overview = new PlayerOverview($container, player2);
+
+    const player1Overview = new PlayerOverview(
+      $container.querySelector(`#player-${matchOrder}-1-overview`),
+      player1
+    );
+    const player2Overview = new PlayerOverview(
+      $container.querySelector(`#player-${matchOrder}-2-overview`),
+      player2
+    );
 
     player1Overview.render();
-
-    const $h2 = document.createElement("h2");
-    $h2.className = "text-white fw-bold mx-3";
-    $h2.textContent = "vs";
-    $container.appendChild($h2);
-
     player2Overview.render();
   }
 }

--- a/frontend/src/components/Game/PvPReady.js
+++ b/frontend/src/components/Game/PvPReady.js
@@ -7,6 +7,7 @@ export default class PvPReady extends Component {
     return `
       <div id="pvp-ready-content" class="d-flex flex-column align-items-center">
         <h1 class="text-white fw-bold">1 vs 1</h1>
+        <div id="player-overviews-holder"></div>
       </div>
     `;
   }
@@ -20,7 +21,7 @@ export default class PvPReady extends Component {
     pageContainer.render();
 
     const playerOverviews = new PlayerOverviews(
-      this.$target.querySelector("#pvp-ready-content"),
+      this.$target.querySelector("#player-overviews-holder"),
       {
         player1: this.props.player1,
         player2: this.props.player2,

--- a/frontend/src/components/Game/TournamentReady.js
+++ b/frontend/src/components/Game/TournamentReady.js
@@ -8,7 +8,10 @@ export default class TournamentReady extends Component {
       <div id="tournament-ready-content" class="d-flex flex-column align-items-center">
         <h1 class="text-white fw-bold">Tournament</h1>
         <h3 class="text-white fw-bold">Round of 4</h3>
-        <div id="overviews-container" class="d-flex"></div>
+        <div id="overviews-container" class="d-flex">
+          <div id="first-match-overview"></div>
+          <div id="second-match-overview"></div>
+        </div>
       </div>
     `;
   }
@@ -22,18 +25,24 @@ export default class TournamentReady extends Component {
 
     const { player1, player2, player3, player4 } = this.props;
 
-    const playerOverviews1 = new PlayerOverviews($overviewsContainer, {
-      player1,
-      player2,
-      type: "tournament",
-      matchOrder: 1,
-    });
-    const playerOverviews2 = new PlayerOverviews($overviewsContainer, {
-      player1: player3,
-      player2: player4,
-      type: "tournament",
-      matchOrder: 2,
-    });
+    const playerOverviews1 = new PlayerOverviews(
+      $overviewsContainer.querySelector("#first-match-overview"),
+      {
+        player1,
+        player2,
+        type: "tournament",
+        matchOrder: 1,
+      }
+    );
+    const playerOverviews2 = new PlayerOverviews(
+      $overviewsContainer.querySelector("#second-match-overview"),
+      {
+        player1: player3,
+        player2: player4,
+        type: "tournament",
+        matchOrder: 2,
+      }
+    );
 
     playerOverviews1.render();
     playerOverviews2.render();

--- a/frontend/src/components/Lobby/GlobalChatContainer.js
+++ b/frontend/src/components/Lobby/GlobalChatContainer.js
@@ -17,46 +17,32 @@ export default class GlobalChatContainer extends Component {
 
   template() {
     return `
+      <h3 class="text-white">
+        Chat (Global)
+      </h2>
       <div
-        id="global-chat-container"
-        class="
-          position-relative
-          col
-          d-flex
-          flex-column
-          align-items-center
-          border border-white border-5
-          p-2
-          g-deep-blue-background
-          "
-        style="height: 35rem;"
+        class="border border-1"
+        style="width: 90%;"
+      ></div>
+      <div
+        id="global-chat-message-container"
+        class="w-100 mh-100 overflow-auto mt-1"
+        style="margin-bottom: 2rem;"
       >
-        <h3 class="text-white">
-          Chat (Global)
-        </h2>
-        <div
-          class="border border-1"
-          style="width: 90%;"
-        ></div>
-        <div
-          id="global-chat-message-container"
-          class="w-100 mh-100 overflow-auto mt-1"
-          style="margin-bottom: 2rem;"
-        >
-          <ul
-            id="global-chat-message-ul"
-            class="list-unstyled"
-          ></ul>
-        </div>
-        <div
-          id="global-chat-input-holder"
-          class="
-            position-absolute bottom-0
-            traslate-middle
-            p-2
-            w-100
-          "></div>
+        <ul
+          id="global-chat-message-ul"
+          class="list-unstyled"
+        ></ul>
       </div>
+      <div
+        id="global-chat-input-holder"
+        class="
+          position-absolute bottom-0
+          traslate-middle
+          p-2
+          w-100
+        "
+      ></div>
     `;
   }
 

--- a/frontend/src/components/Lobby/MatchContainer.js
+++ b/frontend/src/components/Lobby/MatchContainer.js
@@ -5,46 +5,33 @@ import MatchTypeDropdown from "./MatchTypeDropdown.js";
 export default class MatchContainer extends Component {
   template() {
     return `
-      <div
-        id="match-container"
+      <h3
         class="
-          col-md-auto
-          d-flex
-          flex-column
-          align-items-center
-          justify-content-between
-          p-5 me-4
-          border border-white border-5
-          position-relative"
-        style="min-height: 30rem;"
-      >
-        <h3
-          class="
-            position-absolute
-            top-0 start-50
-            translate-middle
-            ps-3 pe-3
-            bg-primary
-            text-white"
-          >
-            Match
-        </h2>
-        <div id="match-type-dropdown" class="dropdown-center mb-5"></div>
-        <h3 class="text-white fw-bold">Play Now!</h3>
-      </div>
+          position-absolute
+          top-0 start-50
+          translate-middle
+          ps-3 pe-3
+          bg-primary
+          text-white"
+        >
+          Match
+      </h2>
+      <div id="match-type-dropdown" class="dropdown-center mb-5"></div>
+      <h3 class="text-white fw-bold">Play Now!</h3>
+      <div id="ball-racket-holder"></div>
     `;
   }
 
   mounted() {
-    const $matchContainer = this.$target.querySelector("#match-container");
-    const $matchTypeDropdownHolder = this.$target.querySelector(
-      "#match-type-dropdown"
+    const matchTypeDropdown = new MatchTypeDropdown(
+      this.$target.querySelector("#match-type-dropdown")
     );
-
-    const matchTypeDropdown = new MatchTypeDropdown($matchTypeDropdownHolder);
-    const bouncingBallOnRacket = new BouncingBallOnRacket($matchContainer, {
-      findingMatch: true,
-    });
+    const bouncingBallOnRacket = new BouncingBallOnRacket(
+      this.$target.querySelector("#ball-racket-holder"),
+      {
+        findingMatch: true,
+      }
+    );
 
     matchTypeDropdown.render();
     bouncingBallOnRacket.render();

--- a/frontend/src/components/Lobby/SideBar.js
+++ b/frontend/src/components/Lobby/SideBar.js
@@ -5,26 +5,17 @@ import ProfileImage from "../UI/Profile/ProfileImage.js";
 export default class SideBar extends Component {
   template() {
     return `
+      <a 
+        id="sidebar-my-profile-link"
+        href="/my-page"
+      ></a>
       <div
+        id="friends-icon-holder"
         class="
-          col col-lg-2
-          d-flex flex-column align-items-center
-          ms-4 gap-3
+          position-relative
+          d-flex justify-content-center
         "
-        style="max-width: 4rem;"
       >
-        <a 
-          id="sidebar-my-profile-link"
-          href="/my-page"
-        ></a>
-        <div
-          id="friends-icon-holder"
-          class="
-            position-relative
-            d-flex justify-content-center
-          "
-        >
-        </div>
       </div>
     `;
   }

--- a/frontend/src/components/SignIn/SignInForm.js
+++ b/frontend/src/components/SignIn/SignInForm.js
@@ -18,7 +18,8 @@ export default class SigninForm extends Component {
       id="sign-in-form"
       class="d-flex flex-column align-items-center"
     >
-      <div id="input-group-container"></div>
+      <div id="id-input-group"></div>
+      <div id="pw-input-group"></div>
       <div
         id="sign-in-warningtext"
         style="
@@ -27,23 +28,20 @@ export default class SigninForm extends Component {
         font-size: 0.2rem; color: #ff9d9d;
         ">
       </div>
-      <div id="sign-in-btn-holder"></div>
+      <div id="signin-btn-holder"></div>
       <text
         class="fw-bold mt-5 mb-2"
         style="color: #b2b2b2"
       >
         Are you not registered?
       </text>
+      <div id="signup-link-holder"></div>
     </form>
     `;
   }
 
   mounted() {
     const $signInForm = this.$target.querySelector("#sign-in-form");
-    const $inputGroupContainer = $signInForm.querySelector(
-      "#input-group-container"
-    );
-    const $signInBtnHolder = $signInForm.querySelector("#sign-in-btn-holder");
 
     const idInputProps = {
       type: "text",
@@ -64,27 +62,39 @@ export default class SigninForm extends Component {
       required: true,
     };
 
-    const idInputGroup = new InputGroup($inputGroupContainer, {
-      labelText: "ID",
-      inputProps: idInputProps,
-      holderId: "id-input-holder",
-    });
-    const pwInputGroup = new InputGroup($inputGroupContainer, {
-      labelText: "Password",
-      inputProps: pwInputProps,
-      holderId: "pw-input-holder",
-    });
-    const signInButton = new Button($signInBtnHolder, {
-      type: "submit",
-      content: "Sign In",
-      disabled: false,
-      attributes: `style="min-width: 10rem"`,
-    });
-    const signUpButton = new Link(this.$target, {
-      content: "Sign Up",
-      href: "/sign-up",
-      attributes: `style="min-width: 10rem"`,
-    });
+    const idInputGroup = new InputGroup(
+      $signInForm.querySelector("#id-input-group"),
+      {
+        labelText: "ID",
+        inputProps: idInputProps,
+        holderId: "id-input-holder",
+      }
+    );
+    const pwInputGroup = new InputGroup(
+      $signInForm.querySelector("#pw-input-group"),
+      {
+        labelText: "Password",
+        inputProps: pwInputProps,
+        holderId: "pw-input-holder",
+      }
+    );
+    const signInButton = new Button(
+      $signInForm.querySelector("#signin-btn-holder"),
+      {
+        type: "submit",
+        content: "Sign In",
+        disabled: false,
+        attributes: `style="min-width: 10rem"`,
+      }
+    );
+    const signUpButton = new Link(
+      $signInForm.querySelector("#signup-link-holder"),
+      {
+        content: "Sign Up",
+        href: "/sign-up",
+        attributes: `style="min-width: 10rem"`,
+      }
+    );
 
     idInputGroup.render();
     pwInputGroup.render();

--- a/frontend/src/components/SignIn/TwoFAForm.js
+++ b/frontend/src/components/SignIn/TwoFAForm.js
@@ -8,6 +8,11 @@ export default class TwoFAForm extends Component {
   constructor($target, props, state) {
     super($target, props, state);
     this.timerInterval = null;
+    this.isFirstRender = true;
+  }
+
+  setup() {
+    this.state = { notifyText: "" };
   }
 
   setEvent() {
@@ -28,7 +33,9 @@ export default class TwoFAForm extends Component {
         "
         data-form-type=${this.props.type}
       >
-        <p id="code-sent-notification" style="color:#c2c2c2;"></p>
+        <p id="code-sent-notification" style="color:#c2c2c2;">
+          ${this.state.notifyText}
+        </p>
         <div
           id="two-fa-group-container"
           class="
@@ -54,12 +61,15 @@ export default class TwoFAForm extends Component {
           >
             03:00
           </span>
+          <div id="code-input-holder"></div>
+          <div id="send-code-btn-holder"></div>
         </div>
         <span
           id="two-fa-warning"
           class="mt-1 fw-bold"
           style="color: #FF9D9D;"
         >Wrong verification code</span>
+        <div id="confirm-btn-holder"></div>
       </form>
 		`;
   }
@@ -70,43 +80,55 @@ export default class TwoFAForm extends Component {
     const $container = this.$target.querySelector("#two-fa-group-container");
     const $form = this.$target.querySelector("#two-fa-form");
 
-    const codeInput = new Input($container, {
-      type: "text",
-      id: "two-fa-code-input",
-      name: "two-fa-code",
-      placeholder: "Your code",
-      autocomplete: false,
-      required: true,
-      className: "mx-2",
-    });
-    const sendCodeButton = new Button($container, {
-      small: true,
-      id: "send-code-btn",
-      name: "send-code-btn",
-      content: "Send again",
-      className: "position-absolute input-group-right",
-      attributes: `style="color: white !important"`,
-    });
-    const confirmButton = new Button($form, {
-      id: `two-fa-${type}`,
-      name: `two-fa-${type}-confirm`,
-      content: type === "signin" ? "Confirm" : "Enable 2FA",
-      small: type === "enable",
-      type: "submit",
-      className: "mt-2",
-      attributes: `style="min-width: 10rem;"`,
-    });
+    const codeInput = new Input(
+      $container.querySelector("#code-input-holder"),
+      {
+        type: "text",
+        id: "two-fa-code-input",
+        name: "two-fa-code",
+        placeholder: "Your code",
+        autocomplete: false,
+        required: true,
+        className: "mx-2",
+      }
+    );
+    const sendCodeButton = new Button(
+      $container.querySelector("#send-code-btn-holder"),
+      {
+        small: true,
+        id: "send-code-btn",
+        name: "send-code-btn",
+        content: "Send again",
+        className: "position-absolute input-group-right",
+        attributes: `style="color: white !important"`,
+      }
+    );
+    const confirmButton = new Button(
+      $form.querySelector("#confirm-btn-holder"),
+      {
+        id: `two-fa-${type}`,
+        name: `two-fa-${type}-confirm`,
+        content: type === "signin" ? "Confirm" : "Enable 2FA",
+        small: type === "enable",
+        type: "submit",
+        className: "mt-2",
+        attributes: `style="min-width: 10rem;"`,
+      }
+    );
 
     codeInput.render();
     sendCodeButton.render();
     confirmButton.render();
 
-    fetchSendCode((email) => this.onCodeSendSuccess(email));
+    if (this.isFirstRender) {
+      fetchSendCode((email) => this.onCodeSendSuccess(email));
+      this.isFirstRender = false;
+    }
   }
 
   onCodeSendSuccess(email) {
+    this.setState({ notifyText: `Verification code has sent to ${email}` });
     this.startTimer(179, this.$target.querySelector("#two-fa-timer"));
-    this.notifyUserCodeHasSent(email);
   }
 
   startTimer(duration, $timerElement) {

--- a/frontend/src/components/SignUp/SignUpForm.js
+++ b/frontend/src/components/SignUp/SignUpForm.js
@@ -14,18 +14,18 @@ export default class SignUpForm extends Component {
       id="sign-up-form"
       class="d-flex flex-column align-items-center"
     >
-      <div id="input-group-container"></div>
-      <div id="sign-up-btn-holder"></div>
+      <div id="id-input-group-holder" class="mt-3"></div>
+      <div id="nickname-input-group-holder"></div>
+      <div id="pw-input-group-holder"></div>
+      <div id="verify-pw-input-group-holder"></div>
+      <div id="email-input-group-holder"></div>
+      <div id="sign-up-btn-holder" class="mt-3"></div>
     </form>
     `;
   }
 
   mounted() {
     const $signUpForm = this.$target.querySelector("#sign-up-form");
-    const $inputGroupContainer = $signUpForm.querySelector(
-      "#input-group-container"
-    );
-    const $signUpBtnHolder = $signUpForm.querySelector("#sign-up-btn-holder");
 
     const idInputProps = {
       type: "text",
@@ -73,42 +73,60 @@ export default class SignUpForm extends Component {
       required: true,
     };
 
-    const idInputGroup = new InputGroup($inputGroupContainer, {
-      labelText: "ID",
-      warningText: "",
-      inputProps: idInputProps,
-      holderId: "id-input-holder",
-    });
-    const nicknameInputGroup = new InputGroup($inputGroupContainer, {
-      labelText: "Nickname",
-      warningText: "",
-      inputProps: nicknameInputProps,
-      holderId: "nickname-input-holder",
-    });
-    const pwInputGroup = new InputGroup($inputGroupContainer, {
-      labelText: "Password",
-      warningText: "",
-      inputProps: pwInputProps,
-      holderId: "pw-input-holder",
-    });
-    const pwVerifyInputGroup = new InputGroup($inputGroupContainer, {
-      labelText: "Verify Password",
-      warningText: "",
-      inputProps: pwVerifyInputProps,
-      holderId: "pw-verify-input-holder",
-    });
-    const emailInputGroup = new InputGroup($inputGroupContainer, {
-      labelText: "E-mail",
-      warningText: "",
-      inputProps: emailInputProps,
-      holderId: "email-input-holder",
-    });
-    const signUpButton = new Button($signUpBtnHolder, {
-      type: "submit",
-      disabled: false,
-      content: "Sign Up",
-      attributes: 'style="min-width: 10rem"',
-    });
+    const idInputGroup = new InputGroup(
+      $signUpForm.querySelector("#id-input-group-holder"),
+      {
+        labelText: "ID",
+        warningText: "",
+        inputProps: idInputProps,
+        holderId: "id-input-holder",
+      }
+    );
+    const nicknameInputGroup = new InputGroup(
+      $signUpForm.querySelector("#nickname-input-group-holder"),
+      {
+        labelText: "Nickname",
+        warningText: "",
+        inputProps: nicknameInputProps,
+        holderId: "nickname-input-holder",
+      }
+    );
+    const pwInputGroup = new InputGroup(
+      $signUpForm.querySelector("#pw-input-group-holder"),
+      {
+        labelText: "Password",
+        warningText: "",
+        inputProps: pwInputProps,
+        holderId: "pw-input-holder",
+      }
+    );
+    const pwVerifyInputGroup = new InputGroup(
+      $signUpForm.querySelector("#verify-pw-input-group-holder"),
+      {
+        labelText: "Verify Password",
+        warningText: "",
+        inputProps: pwVerifyInputProps,
+        holderId: "pw-verify-input-holder",
+      }
+    );
+    const emailInputGroup = new InputGroup(
+      $signUpForm.querySelector("#email-input-group-holder"),
+      {
+        labelText: "E-mail",
+        warningText: "",
+        inputProps: emailInputProps,
+        holderId: "email-input-holder",
+      }
+    );
+    const signUpButton = new Button(
+      $signUpForm.querySelector("#sign-up-btn-holder"),
+      {
+        type: "submit",
+        disabled: false,
+        content: "Sign Up",
+        attributes: 'style="min-width: 10rem"',
+      }
+    );
 
     idInputGroup.render();
     nicknameInputGroup.render();

--- a/frontend/src/components/Start/SignInLink.js
+++ b/frontend/src/components/Start/SignInLink.js
@@ -10,7 +10,7 @@ export default class SignInLink extends Component {
     return `
       <a
         href="${path}"
-        class="btn btn-lg bg-white rounded-pill sign-in-link" 
+        class="btn btn-lg bg-white rounded-pill sign-in-link w-100"  
         ${type === "default-sign-in" ? "data-link" : ""}
       >
         ${content}

--- a/frontend/src/components/UI/Input/InputGroup.js
+++ b/frontend/src/components/UI/Input/InputGroup.js
@@ -13,7 +13,7 @@ export default class InputGroup extends Component {
       d-flex
       align-items-center
       justify-content-center
-      my-3
+      my-2
     ">
       <label 
         for="${inputProps.id}"
@@ -28,7 +28,7 @@ export default class InputGroup extends Component {
         input-group-right
         position-absolute
       ">
-        ${warningText ? warningText : ""}
+        ${warningText || ""}
       </span>
     </div>`;
   }

--- a/frontend/src/core/Component.js
+++ b/frontend/src/core/Component.js
@@ -21,18 +21,7 @@ export default class Component {
   }
 
   render() {
-    if (this.$target.id === "app") {
-      this.$target.innerHTML = this.template();
-    } else {
-      const fragment = document.createDocumentFragment();
-      const tempDiv = document.createElement("div");
-      tempDiv.innerHTML = this.template();
-
-      while (tempDiv.firstChild) {
-        fragment.appendChild(tempDiv.firstChild);
-      }
-      this.$target.appendChild(fragment);
-    }
+    this.$target.innerHTML = this.template();
     this.mounted();
   }
 

--- a/frontend/src/pages/LobbyPage.js
+++ b/frontend/src/pages/LobbyPage.js
@@ -15,6 +15,40 @@ export default class LobbyPage extends Component {
       id="lobby-page-content"
       class="row"
     >
+      <div id="match-container"
+        class="
+          col-md-auto
+          d-flex
+          flex-column
+          align-items-center
+          justify-content-between
+          p-5 me-4
+          border border-white border-5
+          position-relative"
+        style="min-height: 30rem;"
+      ></div>
+      <div
+        id="global-chat-container"
+        class="
+        position-relative
+        col
+        d-flex
+        flex-column
+        align-items-center
+        border border-white border-5
+        p-2
+        g-deep-blue-background
+        "
+        style="height: 35rem;"
+      ></div>
+      <div id="sidebar"
+        class="
+          col col-lg-2
+          d-flex flex-column align-items-center
+          ms-4 gap-3
+        "
+        style="max-width: 4rem;"
+      ></div>
     </div>
     `;
   }
@@ -24,9 +58,14 @@ export default class LobbyPage extends Component {
 
     const $pageContent = this.$target.querySelector("#lobby-page-content");
     const pageContainer = new PageContainerWithLogo(this.$target, $pageContent);
-    const matchContainer = new MatchContainer($pageContent);
-    const globalChatContainer = new GlobalChatContainer($pageContent);
-    const sideBar = new SideBar($pageContent);
+
+    const matchContainer = new MatchContainer(
+      $pageContent.querySelector("#match-container")
+    );
+    const globalChatContainer = new GlobalChatContainer(
+      $pageContent.querySelector("#global-chat-container")
+    );
+    const sideBar = new SideBar($pageContent.querySelector("#sidebar"));
 
     pageContainer.render();
     matchContainer.render();

--- a/frontend/src/pages/SetNicknamePage.js
+++ b/frontend/src/pages/SetNicknamePage.js
@@ -28,6 +28,8 @@ export default class SetNicknamePage extends Component {
             align-items-center
           "
         >
+          <div id="nickname-input-holder" class="mb-3"></div>
+          <div id="nickname-submit-btn-holder"></div>
         </form>
       </div>
     `;
@@ -51,19 +53,25 @@ export default class SetNicknamePage extends Component {
       required: true,
     };
 
-    const nicknameInputGroup = new InputGroup($nicknameForm, {
-      labelText: "Nickname",
-      inputProps: nicknameInputProps,
-      holderId: "nickname-input-holder",
-    });
+    const nicknameInputGroup = new InputGroup(
+      $nicknameForm.querySelector("#nickname-input-holder"),
+      {
+        labelText: "Nickname",
+        inputProps: nicknameInputProps,
+        holderId: "nickname-input-holder",
+      }
+    );
 
-    const setNicknameButton = new Button($nicknameForm, {
-      id: "nickname-submit-btn",
-      type: "submit",
-      disabled: false,
-      content: "Set Nickname",
-      attributes: 'style="min-width: 10rem"',
-    });
+    const setNicknameButton = new Button(
+      $nicknameForm.querySelector("#nickname-submit-btn-holder"),
+      {
+        id: "nickname-submit-btn",
+        type: "submit",
+        disabled: false,
+        content: "Set Nickname",
+        attributes: 'style="min-width: 10rem"',
+      }
+    );
 
     pageContainer.render();
     nicknameInputGroup.render();

--- a/frontend/src/pages/SignInPage.js
+++ b/frontend/src/pages/SignInPage.js
@@ -13,15 +13,18 @@ export default class SignInPage extends Component {
         <div>
           <img src="asset/logo-medium.png" class="img-fluid">
         </div>
+        <div id="signin-form-container"></div>
       </div>
     `;
   }
 
   mounted() {
-    const $SignInContent = this.$target.querySelector("#signin-page-content");
+    const $signInContent = this.$target.querySelector("#signin-page-content");
 
-    const pageContainer = new PageContainer(this.$target, $SignInContent);
-    const signInForm = new SigninForm($SignInContent);
+    const pageContainer = new PageContainer(this.$target, $signInContent);
+    const signInForm = new SigninForm(
+      $signInContent.querySelector("#signin-form-container")
+    );
 
     pageContainer.render();
     signInForm.render();

--- a/frontend/src/pages/SignUpPage.js
+++ b/frontend/src/pages/SignUpPage.js
@@ -13,19 +13,20 @@ export default class SignUpPage extends Component {
         <div>
           <img src="asset/logo-medium.png" class="img-fluid">
         </div>
+        <div id="signup-form-container"></div>
       </div>
     `;
   }
 
   mounted() {
-    const $SignUpContent = this.$target.querySelector(
-      "#signup-page-content"
+    const $signUpContent = this.$target.querySelector("#signup-page-content");
+
+    const pageContainer = new PageContainer(this.$target, $signUpContent);
+    const signUpForm = new SignUpForm(
+      $signUpContent.querySelector("#signup-form-container")
     );
-  
-    const pageContainer = new PageContainer(this.$target, $SignUpContent);
-    const signUpForm = new SignUpForm($SignUpContent);
 
     pageContainer.render();
-    signUpForm.render();  
+    signUpForm.render();
   }
 }

--- a/frontend/src/pages/StartPage.js
+++ b/frontend/src/pages/StartPage.js
@@ -17,7 +17,9 @@ export default class StartPage extends Component {
             src="asset/logo-large.png"
             class="img-fluid"
           />
-          <div id="start-page-link-container" class="d-grid gap-3 mx-auto mt-3">
+          <div class="d-grid gap-3 mx-auto mt-3">
+            <div id="default-signin-link"></div>
+            <div id="oauth-signin-link"></div>
           </div>
         </div>
       </div>
@@ -30,19 +32,21 @@ export default class StartPage extends Component {
     const pageContainer = new PageContainer(this.$target, $pageContent);
     pageContainer.render();
 
-    const $buttonContainer = this.$target.querySelector(
-      "#start-page-link-container"
+    const signInLink = new SignInLink(
+      $pageContent.querySelector("#default-signin-link"),
+      {
+        content: "Sign In",
+        path: "/sign-in",
+        type: "default-sign-in",
+      }
     );
-
-    const signInLink = new SignInLink($buttonContainer, {
-      content: "Sign In",
-      path: "/sign-in",
-      type: "default-sign-in",
-    });
-    const signInWith42Link = new SignInLink($buttonContainer, {
-      content: `Sign In with <img src="asset/42logo.png" style="max-width: 2rem;" />`,
-      path: "http://localhost:8000/api/login/oauth2/42api",
-    });
+    const signInWith42Link = new SignInLink(
+      $pageContent.querySelector("#oauth-signin-link"),
+      {
+        content: `Sign In with <img src="asset/42logo.png" style="max-width: 2rem;" />`,
+        path: "http://localhost:8000/api/login/oauth2/42api",
+      }
+    );
 
     signInLink.render();
     signInWith42Link.render();

--- a/frontend/src/pages/TwoFAPage.js
+++ b/frontend/src/pages/TwoFAPage.js
@@ -13,6 +13,7 @@ export default class TwoFAPage extends Component {
         <div class="mb-5">
           <img src="asset/logo-medium.png" class="img-fluid">
         </div>
+        <div id="two-fa-form-container"></div>
       </div>
     `;
   }
@@ -21,7 +22,10 @@ export default class TwoFAPage extends Component {
     const $signInContent = this.$target.querySelector("#signin-page-content");
 
     const pageContainer = new PageContainer(this.$target, $signInContent);
-    const twoFAForm = new TwoFAForm($signInContent, { type: "signin" });
+    const twoFAForm = new TwoFAForm(
+      $signInContent.querySelector("#two-fa-form-container"),
+      { type: "signin" }
+    );
 
     pageContainer.render();
     twoFAForm.render();


### PR DESCRIPTION
Component의 render 메소드를 롤백하였습니다.
target의 innerHTML을 통째로 갈아 끼웁니다.
이제는 mounted 메소드 내에서 자식 컴포넌트 생성 시, 각 컴포넌트 별로 별개의 div holder를 타겟으로 넘겨줘야 합니다.