### PR TITLE
[Backend] 401 발생시 쿠키 즉시 만료

### DIFF
--- a/backend/backend/exception_handler.py
+++ b/backend/backend/exception_handler.py
@@ -6,10 +6,13 @@ from django.db import IntegrityError
 
 def exception_handler(exc, context):
     response = drf_exception_handler(exc, context)
-
+    if response.status_code == 401:
+        response.set_cookie('access_token', value='', max_age=0)
+        return response
     if response is None:
         if isinstance(exc, IntegrityError):
             return Response({'detail': '중복된 데이터입니다'}, status=status.HTTP_409_CONFLICT)
+
         # else:
         #     return Response({'detail': '알 수 없는 에러입니다'}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 


### PR DESCRIPTION
## 작업 내용
- 401 응답 발생시 쿠키를 즉시 만료시킵니다.
- 금지된 접근은 403으로 처리하니 혼선은 없을 것으로 예상됩니다.