### PR TITLE
[Frontend] 내 프로필 페이지 프로필 이미지 호버 및 내 프로필 페이지 제외 모든 프로필 이미지에 프로필 페이지 링크 추가

### DIFF
--- a/frontend/src/components/Friend/BlockList.js
+++ b/frontend/src/components/Friend/BlockList.js
@@ -16,7 +16,7 @@ export default class BlockList extends Component {
   }
 
   template() {
-    const blocks = blockListStore.getState().blocks;
+    const { blocks } = blockListStore.getState();
 
     if (blocks.length === 0) {
       return `
@@ -81,7 +81,7 @@ export default class BlockList extends Component {
   }
 
   mounted() {
-    const blocks = blockListStore.getState().blocks;
+    const { blocks } = blockListStore.getState();
 
     if (blocks.length > 0) {
       blocks.forEach((block) => {

--- a/frontend/src/components/Friend/FriendList.js
+++ b/frontend/src/components/Friend/FriendList.js
@@ -20,7 +20,7 @@ export default class FriendList extends Component {
   }
 
   template() {
-    const friends = friendListStore.getState().friends;
+    const { friends } = friendListStore.getState();
 
     if (friends.length === 0) {
       return `
@@ -95,7 +95,7 @@ export default class FriendList extends Component {
   }
 
   mounted() {
-    const friends = friendListStore.getState().friends;
+    const { friends } = friendListStore.getState();
 
     if (friends.length > 0) {
       friends.forEach((friend) => {

--- a/frontend/src/components/Lobby/GlobalMessage.js
+++ b/frontend/src/components/Lobby/GlobalMessage.js
@@ -4,7 +4,7 @@ import formatTime from "../../utils/formatTime.js";
 
 export default class GlobalMessage extends Component {
   template() {
-    const { content, senderId, senderNickname, datetime } = this.props;
+    const { content, senderNickname, datetime } = this.props;
 
     return `
       <div class="d-flex">
@@ -27,7 +27,11 @@ export default class GlobalMessage extends Component {
   mounted() {
     const senderImage = new ProfileImage(
       this.$target.querySelector("#sender-img-holder"),
-      { imageSize: "image-xs", imageSrc: this.props.senderProfileImage }
+      {
+        userId: this.props.senderId,
+        imageSize: "image-xs",
+        imageSrc: this.props.senderProfileImage,
+      }
     );
     senderImage.render();
   }

--- a/frontend/src/components/Lobby/SideBar.js
+++ b/frontend/src/components/Lobby/SideBar.js
@@ -11,19 +11,16 @@ export default class SideBar extends Component {
 
   template() {
     return `
-      <a 
-        id="sidebar-my-profile-link"
-        href="/profile?user_id=${myInfoStore.getState().userId}"
-        data-link
-      ></a>
+      <div id="sidebar-my-profile-image-holder"></div>
       <div id="sidebar-friend-content"></div>
     `;
   }
 
   mounted() {
     const myProfile = new ProfileImage(
-      this.$target.querySelector("#sidebar-my-profile-link"),
+      this.$target.querySelector("#sidebar-my-profile-image-holder"),
       {
+        userId: myInfoStore.getState().userId,
         imageSize: "image-sm",
         imageSrc: myInfoStore.getState().profileImage,
         alt: "my profile",
@@ -31,6 +28,7 @@ export default class SideBar extends Component {
     );
     const friend = new Friend(
       this.$target.querySelector("#sidebar-friend-content"),
+      {},
       this
     );
 

--- a/frontend/src/components/Profile/MatchHistoryCard.js
+++ b/frontend/src/components/Profile/MatchHistoryCard.js
@@ -40,11 +40,13 @@ export default class MatchHistoryCard extends Component {
     );
 
     const leftProfileImage = new ProfileImage($leftProfileImageContent, {
+      userId: this.props.left_user.id,
       imageSize: "image-sm",
       imageSrc: `${this.props.left_user.profile_image}`,
       alt: `${this.props.left_user.nickname}`,
     });
     const rightProfileImage = new ProfileImage($rightProfileImageContent, {
+      userId: this.props.right_user.id,
       imageSize: "image-sm",
       imageSrc: `${this.props.right_user.profile_image}`,
       alt: `${this.props.right_user.nickname}`,

--- a/frontend/src/components/Profile/Profile.js
+++ b/frontend/src/components/Profile/Profile.js
@@ -131,15 +131,16 @@ export default class Profile extends Component {
 
   mounted() {
     const { userInfo, isEditingNickname } = this.state;
-    const { imageSize, alt, isMe } = this.props;
+    const { isMe } = this.props;
     const myInfo = myInfoStore.getState();
 
     const profileImage = new ProfileImage(
       this.$target.querySelector("#profile-image-content"),
       {
-        imageSize,
-        imageSrc: isMe ? myInfo.profileImage : "asset/default.png",
-        alt,
+        imageSize: "image-mid",
+        imageSrc: isMe ? myInfo.profileImage : userInfo.profileImage,
+        alt: isMe ? myInfo.nickname : userInfo.nickname,
+        isMyProfile: isMe,
       }
     );
 

--- a/frontend/src/components/UI/Profile/ProfileImage.css
+++ b/frontend/src/components/UI/Profile/ProfileImage.css
@@ -1,3 +1,26 @@
+.profile-hover {
+  position: relative;
+}
+
+.edit-icon {
+  display: none;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 24px;
+  color: white;
+}
+
+.profile-hover:hover .edit-icon {
+  display: block;
+  z-index: 10;
+}
+
+.profile-hover:hover img {
+  opacity: 0.5;
+}
+
 .image-big {
   width: 10rem;
   height: 10rem;

--- a/frontend/src/components/UI/Profile/ProfileImage.js
+++ b/frontend/src/components/UI/Profile/ProfileImage.js
@@ -6,15 +6,26 @@ appendCSSLink("src/components/UI/Profile/ProfileImage.css");
 export default class ProfileImage extends Component {
   template() {
     const {
+      userId,
       imageSize, // image-big, image-mid, image-sm
       imageSrc,
       alt,
+      isMyProfile,
     } = this.props;
 
     return `
-      <div class="overflow-hidden rounded-circle ${imageSize}">
+    ${!isMyProfile && userId ? `<a href="/profile?user_id=${userId}" data-link>` : ""}
+      <div class="overflow-hidden rounded-circle ${imageSize} ${isMyProfile ? "profile-hover" : ""}">
         <img class="img-fluid" src=${imageSrc} alt=${alt}>
+        ${
+          isMyProfile
+            ? `<svg xmlns="http://www.w3.org/2000/svg" width="25" height="25" fill="currentColor" class="bi bi-pencil-fill edit-icon" viewBox="0 0 16 16">
+                <path d="M12.854.146a.5.5 0 0 0-.707 0L10.5 1.793 14.207 5.5l1.647-1.646a.5.5 0 0 0 0-.708zm.646 6.061L9.793 2.5 3.293 9H3.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.207zm-7.468 7.468A.5.5 0 0 1 6 13.5V13h-.5a.5.5 0 0 1-.5-.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.5-.5V10h-.5a.5.5 0 0 1-.175-.032l-.179.178a.5.5 0 0 0-.11.168l-2 5a.5.5 0 0 0 .65.65l5-2a.5.5 0 0 0 .168-.11z"/>
+              </svg>`
+            : ""
+        }
       </div>
+    ${!isMyProfile && userId ? `</a>` : ""}
     `;
   }
 }

--- a/frontend/src/pages/ProfilePage.js
+++ b/frontend/src/pages/ProfilePage.js
@@ -40,12 +40,6 @@ export default class ProfilePage extends Component {
     const profileContent = new Profile(
       $profileContainer.querySelector("#profile-content"),
       {
-        username: "hyeonjun",
-        imageSize: "image-mid",
-        imageSrc: "asset/default.png",
-        alt: "my profile",
-        wins: 42,
-        losses: 42,
         userId,
         isMe,
       },


### PR DESCRIPTION
- 내 프로필 페이지의 프로필 이미지에 호버를 추가하여 수정할 수 있음을 표시하였습니다.
<img width="351" alt="image" src="https://github.com/MyLittleTranscendence/ft_transcendence/assets/67998022/3ab67641-2153-4484-b5c3-9a4a7f6ed9e2">

- 게임 페이지를 제외한 모든 ProfileImage 클릭 시 프로필 페이지로 이동하도록 하였습니다.