### PR TITLE
[Frontend] 토너먼트 결과 모달 내 컨텐츠 표시 오류

### DIFF
--- a/frontend/src/components/Game/TournamentGameResultModal.js
+++ b/frontend/src/components/Game/TournamentGameResultModal.js
@@ -5,21 +5,31 @@ import ProfileImage from "../UI/Profile/ProfileImage.js";
 import fetchUserInfo from "../../api/user/fetchUserInfo.js";
 
 export default class TournamentGameResultModal extends Modal {
-  async mounted() {
+  async setup() {
     if (this.props.isFinal) {
-      const { winner } = this.props;
+      this.state = { winnerInfo: null };
+      const winnerInfo = await fetchUserInfo(this.props.winner);
+      this.setState({ winnerInfo });
+    }
+  }
 
+  mounted() {
+    if (this.props.isFinal) {
       this.$modalTitle.textContent = "Winner of The Tournament";
 
-      const winnerInfo = await fetchUserInfo(winner);
+      const { winnerInfo } = this.state;
 
-      const winnerImage = new ProfileImage(this.$userImgaeHolder, {
+      const winnerImage = new ProfileImage(this.$userImageHolder, {
+        userId: winnerInfo ? winnerInfo.userId : null,
         imageSize: "image-mid",
-        imageSrc: winnerInfo.profileImage,
+        imageSrc: winnerInfo ? winnerInfo.profileImage : null,
+        alt: `${winnerInfo ? winnerInfo.nickname : ""}\`s profile`,
       });
       winnerImage.render();
 
-      this.$textContent.textContent = winnerInfo.nickname;
+      this.$textContent.textContent = winnerInfo
+        ? winnerInfo.nickname
+        : "Loading...";
 
       const goHomeLink = new Link(this.$modalButtonGroup, {
         id: "modal-close",

--- a/frontend/src/components/UI/Profile/ProfileImage.js
+++ b/frontend/src/components/UI/Profile/ProfileImage.js
@@ -16,7 +16,7 @@ export default class ProfileImage extends Component {
     return `
     ${!isMyProfile && userId ? `<a href="/profile?user_id=${userId}" data-link>` : ""}
       <div class="overflow-hidden rounded-circle ${imageSize} ${isMyProfile ? "profile-hover" : ""}">
-        <img class="img-fluid" src=${imageSrc} alt=${alt}>
+        <img class="img-fluid" src=${imageSrc || "asset/default.png"} alt=${alt}>
         ${
           isMyProfile
             ? `<svg xmlns="http://www.w3.org/2000/svg" width="25" height="25" fill="currentColor" class="bi bi-pencil-fill edit-icon" viewBox="0 0 16 16">

--- a/frontend/src/core/router.js
+++ b/frontend/src/core/router.js
@@ -63,6 +63,7 @@ const initRouter = () => {
       if (newUrl.href !== currentUrl.href) {
         window.history.pushState({}, "", newUrl.href);
       }
+      document.getElementById("modal-root").innerHTML = "";
       handleRouteChange();
     };
 


### PR DESCRIPTION
이미지 홀더 엘리먼트를 인자로 넘겨줄 때 오타가 있어 수정하였습니다.
추가로, setup 함수를 비동기 함수로 지정하여 우승자 정보 요청 및 setState를 호출함으로써 컨텐츠가 늦게 로딩되지 않도록 했습니다.