### PR TITLE
[Frontend] 채팅 세션스토리지 저장

### DIFF
--- a/backend/chat/consumers.py
+++ b/backend/chat/consumers.py
@@ -57,10 +57,10 @@ class ChatConsumer(DefaultConsumer):
         message = message_data["message"]
         receiver_id = message_data["receiver_id"]
         sender_id = self.scope['user'].id
-        await self.send_message_to_group(f"{sender_id}_chat", message, "single.message")
-        await self.send_message_to_group(f"{receiver_id}_chat", message, "single.message")
+        await self.send_message_to_group(f"{sender_id}_chat", message, "single.message", receiver_id)
+        await self.send_message_to_group(f"{receiver_id}_chat", message, "single.message", receiver_id)
 
-    async def send_message_to_group(self, group, message, type):
+    async def send_message_to_group(self, group, message, type, receiver_id=0):
         """
         그룹에게 메시지 전송
         """
@@ -71,7 +71,8 @@ class ChatConsumer(DefaultConsumer):
                 "sender_id": self.scope['user'].id,
                 "sender_nickname": self.nickname,
                 "sender_profile_image": self.profile_image,
-                "datetime": str(now())
+                "datetime": str(now()),
+                "receiver_id": receiver_id
             })
 
     async def handle_login_status(self, status):
@@ -118,7 +119,8 @@ class ChatConsumer(DefaultConsumer):
             "sender_id": event["sender_id"],
             "sender_nickname": event["sender_nickname"],
             "sender_profile_image": event["sender_profile_image"],
-            "datetime": event["datetime"]
+            "datetime": event["datetime"],
+            "receiver_id": event['receiver_id']
         }))
 
     async def friend_login(self, event):

--- a/frontend/global.css
+++ b/frontend/global.css
@@ -2,6 +2,14 @@
   color: #c1c1c1;
 }
 
+.g-grey {
+  color: grey;
+}
+
+.g-dark-grey {
+  color: rgb(63, 63, 63);
+}
+
 .g-deep-blue-background {
   background-color: #0049d8;
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,6 +4,7 @@ import fetchMyInfo from "./api/user/fetchMyInfo.js";
 import Component from "./core/Component.js";
 import getRouter from "./core/router.js";
 import routes from "./core/routes.js";
+import { storeChatMessageToSessionStorage } from "./handlers/chat/chatHandler.js";
 
 export default class App extends Component {
   template() {
@@ -27,6 +28,7 @@ export default class App extends Component {
           localStorage.setItem("login", "true");
           fetchFriendList();
           fetchBlockList();
+          storeChatMessageToSessionStorage();
           if (
             ["/start", "/sign-in", "/sign-up", "/mfa"].includes(currentPath)
           ) {

--- a/frontend/src/components/Friend/DirectMessage.js
+++ b/frontend/src/components/Friend/DirectMessage.js
@@ -1,20 +1,23 @@
 import Component from "../../core/Component.js";
+import { myInfoStore } from "../../store/initialStates.js";
 import formatTime from "../../utils/formatTime.js";
 
 export default class DirectMessage extends Component {
   template() {
     const { content, senderId, senderNickname, datetime } = this.props;
+    const { userId: myId } = myInfoStore.getState();
+    const isMe = senderId === myId;
 
     return `
       <div class="d-flex">
         <div class="ms-2">
-          <span class="fw-bold g-light-grey">
-            ${senderNickname}
-            <span class="text-warning fw-light fst-italic fs-6">
+          <span class="fw-bold ${isMe ? "text-primary" : "g-grey"}">
+            ${isMe ? "Me" : senderNickname}
+            <span class="g-light-grey fw-light fst-italic fs-6">
               ${formatTime(datetime)}
             </span>
           </span>
-          <p class="g-light-grey">
+          <p class="g-dark-grey">
             ${content}
           </p>
         </div>

--- a/frontend/src/components/Friend/DirectMessageContainer.js
+++ b/frontend/src/components/Friend/DirectMessageContainer.js
@@ -33,13 +33,8 @@ export default class DirectMessageContainer extends Component {
           <span class="text-muted fw-bold fs-4 mx-2">${this.props.nickname}</span>
         </div>
         <hr>
-        <div class="overflow-auto" style="height: 25rem; max-height: 25rem;">
-          <div
-            id="dm-chat-message-container"
-            class="w-100 mh-100 overflow-auto mt-1"
-          >
-            <ul id="dm-chat-message-ul" class="list-unstyled"></ul>
-          </div>
+        <div id="dm-chat-message-container" class="overflow-auto" style="height: 25rem;">
+          <ul id="dm-chat-message-ul" class="list-unstyled"></ul>
         </div>
         <div id="dm-chat-input-holder"></div>
       </div>

--- a/frontend/src/components/Friend/DirectMessageContainer.js
+++ b/frontend/src/components/Friend/DirectMessageContainer.js
@@ -10,19 +10,24 @@ import { myInfoStore } from "../../store/initialStates.js";
 
 export default class DirectMessageContainer extends Component {
   setEvent() {
+    const { userId: opponentId } = this.props;
     this.addEvent("keydown", "#dm-chat-input", (e) =>
-      sendChatHandler(e, "single_message", this.props.userId)
+      sendChatHandler(e, "single_message", opponentId)
     );
     this.addEvent("click", "#send-icon", () => {
       const $input = this.$target.querySelector("#dm-chat-input");
       sendChatHandler(
         { target: $input, key: "Enter" },
         "single_message",
-        this.props.userId
+        opponentId
       );
     });
 
-    receiveSingleChatMessageHandler(this.$target, this.removeObservers);
+    receiveSingleChatMessageHandler(
+      this.$target,
+      this.removeObservers,
+      opponentId
+    );
   }
 
   template() {
@@ -64,6 +69,7 @@ export default class DirectMessageContainer extends Component {
 
   loadStoredChatMessages() {
     const { userId: myId } = myInfoStore.getState();
+    const { userId: opponentId } = this.props;
 
     const storedMessages =
       JSON.parse(sessionStorage.getItem("direct_message")) || [];
@@ -72,8 +78,8 @@ export default class DirectMessageContainer extends Component {
 
     storedMessages.forEach((message) => {
       if (
-        message.sender_id === this.props.userId ||
-        message.sender_id === myId
+        (message.sender_id === myId && message.receiver_id === opponentId) ||
+        (message.sender_id === opponentId && message.receiver_id === myId)
       ) {
         appendDirectMessageToUL($messageUL, message);
       }

--- a/frontend/src/components/Lobby/GlobalChatContainer.js
+++ b/frontend/src/components/Lobby/GlobalChatContainer.js
@@ -1,7 +1,10 @@
 import Component from "../../core/Component.js";
 import ChatInput from "./ChatInput.js";
 import sendChatHandler from "../../handlers/chat/sendChatHandler.js";
-import { receiveTotalChatMessageHandler } from "../../handlers/chat/chatHandler.js";
+import {
+  receiveTotalChatMessageHandler,
+  appendGlobalMessageToUL,
+} from "../../handlers/chat/chatHandler.js";
 import receiveLogoutHandler from "../../handlers/auth/socketLogoutHandler.js";
 import { chatSocket } from "../../socket/socketManager.js";
 
@@ -51,6 +54,15 @@ export default class GlobalChatContainer extends Component {
   }
 
   mounted() {
+    const storedMessages =
+      JSON.parse(sessionStorage.getItem("global_message")) || [];
+
+    const $messageUL = this.$target.querySelector("#global-chat-message-ul");
+
+    storedMessages.forEach((message) => {
+      appendGlobalMessageToUL($messageUL, message);
+    });
+
     const chatInput = new ChatInput(
       this.$target.querySelector("#global-chat-input-holder"),
       { id: "global-chat-input", name: "global-chat-input" }

--- a/frontend/src/handlers/chat/chatHandler.js
+++ b/frontend/src/handlers/chat/chatHandler.js
@@ -1,24 +1,39 @@
 import { chatSocket } from "../../socket/socketManager.js";
 import GlobalMessage from "../../components/Lobby/GlobalMessage.js";
-import { blockListStore } from "../../store/initialStates.js";
+import DirectMessage from "../../components/Friend/DirectMessage.js";
 
-const isBlockedUser = (senderId) => {
-  const blocks = blockListStore.getState().blocks;
+const appendGlobalMessageToUL = ($ul, message) => {
+  const $li = document.createElement("li");
+  const globalMessage = new GlobalMessage($li, {
+    content: message.message,
+    senderId: message.sender_id,
+    senderNickname: message.sender_nickname,
+    senderProfileImage: message.sender_profile_image,
+    datetime: message.datetime,
+  });
+  globalMessage.render();
+  $li.id = `global-${message.datetime}`;
+  $ul.appendChild($li);
+};
 
-  if (blocks.find((blockedUser) => blockedUser.userId === senderId)) {
-    return true;
-  }
-  return false;
+const appendDirectMessageToUL = ($ul, message) => {
+  const $li = document.createElement("li");
+  const directMessage = new DirectMessage($li, {
+    content: message.message,
+    senderId: message.sender_id,
+    senderNickname: message.sender_nickname,
+    senderProfileImage: message.sender_profile_image,
+    datetime: message.datetime,
+  });
+  directMessage.render();
+  $li.id = `dm-${message.datetime}`;
+  $ul.appendChild($li);
 };
 
 const receiveTotalChatMessageHandler = ($target, removeObservers) => {
   const { addSocketObserver } = chatSocket();
 
   const removeObserver = addSocketObserver("total_message", (message) => {
-    if (isBlockedUser(message.sender_id)) {
-      return;
-    }
-
     const $messageContainer = $target.querySelector(
       "#global-chat-message-container"
     );
@@ -26,21 +41,80 @@ const receiveTotalChatMessageHandler = ($target, removeObservers) => {
       "#global-chat-message-ul"
     );
 
-    const $messageLI = document.createElement("li");
-    const globalMessage = new GlobalMessage($messageLI, {
-      content: message.message,
-      senderId: message.sender_id,
-      senderNickname: message.sender_nickname,
-      senderProfileImage: message.sender_profile_image,
-      datetime: message.datetime,
-    });
-    globalMessage.render();
-    $messageLI.id = `global-${message.datetime}`;
-    $messageUL.appendChild($messageLI);
+    appendGlobalMessageToUL($messageUL, message);
     $messageContainer.scrollTop = $messageContainer.scrollHeight;
   });
 
   removeObservers.push(removeObserver);
 };
 
-export { receiveTotalChatMessageHandler };
+const receiveSingleChatMessageHandler = ($target, removeObservers) => {
+  const { addSocketObserver } = chatSocket();
+
+  const removeObserver = addSocketObserver("single_message", (message) => {
+    const $messageContainer = $target.querySelector(
+      "#dm-chat-message-container"
+    );
+    const $messageUL = $messageContainer.querySelector("#dm-chat-message-ul");
+
+    appendDirectMessageToUL($messageUL, message);
+    $messageContainer.scrollTop = $messageContainer.scrollHeight;
+  });
+  removeObservers.push(removeObserver);
+};
+
+const storeChatMessageToSessionStorage = () => {
+  const { addSocketObserver } = chatSocket();
+
+  let currentMessages;
+
+  const storeAndUpdateMessages = (type, message) => {
+    try {
+      currentMessages = JSON.parse(sessionStorage.getItem(type)) || [];
+
+      const newMessage = {
+        message: message.message,
+        sender_id: message.sender_id,
+        sender_nickname: message.sender_nickname,
+        sender_profile_image: message.sender_profile_image,
+        datetime: message.datetime,
+      };
+
+      currentMessages.push(newMessage);
+
+      sessionStorage.setItem(type, JSON.stringify(currentMessages));
+    } catch (e) {
+      // QuotaExceededError: sessionStorage 용량 제한 초과 시 발생
+      if (e.name === "QuotaExceededError") {
+        while (currentMessages.length > 0) {
+          currentMessages.shift();
+          try {
+            sessionStorage.setItem(type, JSON.stringify(currentMessages));
+            break;
+          } catch (error) {
+            if (error.name !== "QuotaExceededError") {
+              throw error;
+            }
+          }
+        }
+      } else {
+        throw e;
+      }
+    }
+  };
+
+  addSocketObserver("total_message", (message) =>
+    storeAndUpdateMessages("global_message", message)
+  );
+  addSocketObserver("single_message", (message) =>
+    storeAndUpdateMessages("direct_message", message)
+  );
+};
+
+export {
+  receiveTotalChatMessageHandler,
+  receiveSingleChatMessageHandler,
+  storeChatMessageToSessionStorage,
+  appendGlobalMessageToUL,
+  appendDirectMessageToUL,
+};


### PR DESCRIPTION
- 받는 모든 채팅 메시지를 세션스토리지에 저장하는 옵저버를 등록하는 핸들러를  App 컴포넌트에서 호출하였습니다.
- 전체채팅 컴포넌트, DM 컴포넌트 마운트 시 세션스토리지에 저장된 메시지를 불러와 로드합니다.
- 추가로, DM 메시지의 닉네임을 상대방과 다르게 표시되도록 하였습니다.
- 특정 상대와의 대화에 제 3자가 보낸 DM이 표시되는 문제를 수정하였습니다.

<img width="409" alt="image" src="https://github.com/MyLittleTranscendence/ft_transcendence/assets/67998022/5cd0d500-42b0-412a-8cf0-6fd9f89811ee">
<img width="411" alt="image" src="https://github.com/MyLittleTranscendence/ft_transcendence/assets/67998022/d13d2513-e9cf-4a78-83f0-dfd62a86b0d3">
