### PR TITLE
[Frontend] 게임 시작 시 준비 화면에서 next game 소켓 메시지 받을 시 알림 팝업

### DIFF
--- a/frontend/Index.html
+++ b/frontend/Index.html
@@ -18,7 +18,8 @@
     <div id="root"></div>
     <div
       id="toast-container"
-      class="position-absolute translate-middle start-50"
+      class="position-fixed translate-middle start-50"
+      style="top: 5rem"
     ></div>
     <div id="modal-root"></div>
     <script async src="./src/index.js" type="module"></script>

--- a/frontend/src/components/Game/PongGame.js
+++ b/frontend/src/components/Game/PongGame.js
@@ -5,6 +5,7 @@ import {
   updateGameHandler,
   gameKeyDownHandler,
   gameReadyCountdownHandler,
+  nextGameAlertHandler,
 } from "../../handlers/game/gameHandler.js";
 import MultiGameResultModal from "./MultiGameResultModal.js";
 import TournamentGameResultModal from "./TournamentGameResultModal.js";
@@ -29,6 +30,8 @@ export default class PongGame extends Component {
     if ([leftUserId, rightUserId].includes(userId)) {
       gameKeyDownHandler(this.removeObservers);
     }
+
+    nextGameAlertHandler(this.removeObservers);
   }
 
   template() {

--- a/frontend/src/components/Lobby/MatchContainer.js
+++ b/frontend/src/components/Lobby/MatchContainer.js
@@ -21,6 +21,7 @@ import {
 } from "../../handlers/game/matchMakingHandlers.js";
 import { gameSocket } from "../../socket/socketManager.js";
 import receiveLogoutHandler from "../../handlers/auth/socketLogoutHandler.js";
+import { nextGameAlertHandler } from "../../handlers/game/gameHandler.js";
 
 appendCSSLink("src/components/Lobby/TimeLeftBar.css");
 
@@ -76,6 +77,7 @@ export default class MatchContainer extends Component {
     receiveGameInviteHandler(this.removeObservers);
     invitationFailHandler(this.removeObservers);
     receiveLogoutHandler(this.removeObservers, gameSocket);
+    nextGameAlertHandler(this.removeObservers);
   }
 
   template() {

--- a/frontend/src/components/UI/Toast/Toast.js
+++ b/frontend/src/components/UI/Toast/Toast.js
@@ -19,10 +19,15 @@ export default class Toast extends Component {
   }
 
   show(content) {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.$toastContent.classList.remove("show");
+    }
     this.$toastContent.textContent = content;
     this.$toastContent.classList.add("show");
-    setTimeout(() => {
+    this.timer = setTimeout(() => {
       this.$toastContent.classList.remove("show");
+      this.timer = null;
     }, 4400);
   }
 }

--- a/frontend/src/components/UI/Toast/Toast.js
+++ b/frontend/src/components/UI/Toast/Toast.js
@@ -21,7 +21,6 @@ export default class Toast extends Component {
   show(content) {
     if (this.timer) {
       clearTimeout(this.timer);
-      this.$toastContent.classList.remove("show");
     }
     this.$toastContent.textContent = content;
     this.$toastContent.classList.add("show");

--- a/frontend/src/handlers/game/gameHandler.js
+++ b/frontend/src/handlers/game/gameHandler.js
@@ -180,8 +180,8 @@ const cliSendHandler = (command) => {
 const nextGameAlertHandler = (removeObservers) => {
   const { addSocketObserver } = gameSocket();
 
-  const removeObserver = addSocketObserver("next_game", (message) => {
-    showToast(message.message);
+  const removeObserver = addSocketObserver("next_game", () => {
+    showToast("Your match will start after current one. Be prepared!");
   });
 
   removeObservers.push(removeObserver);

--- a/frontend/src/handlers/game/gameHandler.js
+++ b/frontend/src/handlers/game/gameHandler.js
@@ -1,6 +1,7 @@
 import { gameSocket } from "../../socket/socketManager.js";
 import { gameInfoStore } from "../../store/initialStates.js";
 import getRouter from "../../core/router.js";
+import showToast from "../../utils/showToast.js";
 
 const waitGameHandler = (removeObservers) => {
   const { addSocketObserver } = gameSocket();
@@ -176,6 +177,16 @@ const cliSendHandler = (command) => {
   sendSocket("move_bar", { command });
 };
 
+const nextGameAlertHandler = (removeObservers) => {
+  const { addSocketObserver } = gameSocket();
+
+  const removeObserver = addSocketObserver("next_game", (message) => {
+    showToast(message.message);
+  });
+
+  removeObservers.push(removeObserver);
+};
+
 export {
   waitGameHandler,
   infoGameHandler,
@@ -183,4 +194,5 @@ export {
   gameKeyDownHandler,
   gameReadyCountdownHandler,
   cliSendHandler,
+  nextGameAlertHandler,
 };

--- a/frontend/src/pages/TournamentReadyPage.js
+++ b/frontend/src/pages/TournamentReadyPage.js
@@ -2,7 +2,10 @@ import Component from "../core/Component.js";
 import PageContainerWithLogo from "../components/UI/Container/PageContainerWithLogo.js";
 import PlayerOverviews from "../components/Game/PlayerOverviews.js";
 import { tournamentBeginUserIdStore } from "../store/initialStates.js";
-import { waitGameHandler } from "../handlers/game/gameHandler.js";
+import {
+  waitGameHandler,
+  nextGameAlertHandler,
+} from "../handlers/game/gameHandler.js";
 
 export default class TournamentReadyPage extends Component {
   template() {
@@ -20,6 +23,7 @@ export default class TournamentReadyPage extends Component {
 
   mounted() {
     waitGameHandler(this.removeObservers);
+    nextGameAlertHandler(this.removeObservers);
 
     const $content = this.$target.querySelector("#tournament-ready-content");
     const $overviewsContainer = $content.querySelector("#overviews-container");


### PR DESCRIPTION
next_game 메시지를 받으면 알림 toast를 띄우도록 했습니다.
추가로, toast가 보이지 않는 경우(게임 페이지 혹은 내 프로필 페이지에서 전적이 많을 경우)가 있어, toast 위치를 뷰포트 기준 상단에 나타나도록 수정하였습니다.

<img width="1140" alt="image" src="https://github.com/MyLittleTranscendence/ft_transcendence/assets/67998022/99919698-8ee7-4fb1-8fdd-c77af92026ac">
