### PR TITLE
[Frontend] 페이지 리로드 없이 재로그인일반 로그인 시 소켓 연결 안 됨

### DIFF
--- a/frontend/src/components/Game/PongGame.js
+++ b/frontend/src/components/Game/PongGame.js
@@ -10,7 +10,7 @@ import MultiGameResultModal from "./MultiGameResultModal.js";
 import TournamentGameResultModal from "./TournamentGameResultModal.js";
 import SingleGameResultModal from "./SingleGameResultModal.js";
 import receiveLogoutHandler from "../../handlers/auth/socketLogoutHandler.js";
-import { gameSocket } from "../../socket/socketManager.js";
+import { gameSocket } from "../../socket/socket.js";
 
 export default class PongGame extends Component {
   setEvent() {

--- a/frontend/src/components/Lobby/GameInviteModal.js
+++ b/frontend/src/components/Lobby/GameInviteModal.js
@@ -1,7 +1,7 @@
 import Modal from "../UI/Modal/Modal.js";
 import ProfileImage from "../UI/Profile/ProfileImage.js";
 import Button from "../UI/Button/Button.js";
-import { gameSocket } from "../../socket/socketManager.js";
+import { gameSocket } from "../../socket/socket.js";
 
 export default class GameInviteModal extends Modal {
   setEvent() {

--- a/frontend/src/components/Lobby/GlobalChatContainer.js
+++ b/frontend/src/components/Lobby/GlobalChatContainer.js
@@ -6,7 +6,7 @@ import {
   appendGlobalMessageToUL,
 } from "../../handlers/chat/chatHandler.js";
 import receiveLogoutHandler from "../../handlers/auth/socketLogoutHandler.js";
-import { chatSocket } from "../../socket/socketManager.js";
+import { chatSocket } from "../../socket/socket.js";
 
 export default class GlobalChatContainer extends Component {
   setEvent() {

--- a/frontend/src/components/Lobby/MatchContainer.js
+++ b/frontend/src/components/Lobby/MatchContainer.js
@@ -19,7 +19,7 @@ import {
   tournamentBeginHandler,
   receiveGameInviteHandler,
 } from "../../handlers/game/matchMakingHandlers.js";
-import { gameSocket } from "../../socket/socketManager.js";
+import { gameSocket } from "../../socket/socket.js";
 import receiveLogoutHandler from "../../handlers/auth/socketLogoutHandler.js";
 
 appendCSSLink("src/components/Lobby/TimeLeftBar.css");

--- a/frontend/src/handlers/auth/logoutHandler.js
+++ b/frontend/src/handlers/auth/logoutHandler.js
@@ -1,6 +1,7 @@
 import fetchAPI from "../../utils/fetchAPI.js";
 import getRouter from "../../core/router.js";
 import showToast from "../../utils/showToast.js";
+import { gameSocket, chatSocket } from "../../socket/socket.js";
 
 const logoutHandler = () => {
   const { navigate } = getRouter();
@@ -10,6 +11,10 @@ const logoutHandler = () => {
     .then(() => {
       navigate("/start");
       showToast("Bye bye!");
+      const { clearSocket: clearGameSocket } = gameSocket();
+      const { clearSocket: clearChatSocket } = chatSocket();
+      clearGameSocket();
+      clearChatSocket();
     })
     .catch(() => showToast("Logout failed"));
 };

--- a/frontend/src/handlers/chat/chatHandler.js
+++ b/frontend/src/handlers/chat/chatHandler.js
@@ -1,4 +1,4 @@
-import { chatSocket } from "../../socket/socketManager.js";
+import { chatSocket } from "../../socket/socket.js";
 import GlobalMessage from "../../components/Lobby/GlobalMessage.js";
 import DirectMessage from "../../components/Friend/DirectMessage.js";
 import { myInfoStore } from "../../store/initialStates.js";

--- a/frontend/src/handlers/chat/onlineCheckHandler.js
+++ b/frontend/src/handlers/chat/onlineCheckHandler.js
@@ -1,4 +1,4 @@
-import { chatSocket } from "../../socket/socketManager.js";
+import { chatSocket } from "../../socket/socket.js";
 import OnlineIcon from "../../components/UI/Icon/OnlineIcon.js";
 
 const onlineCheckHandler = ($holder, userId, removeObservers) => {

--- a/frontend/src/handlers/chat/sendChatHandler.js
+++ b/frontend/src/handlers/chat/sendChatHandler.js
@@ -1,4 +1,4 @@
-import { chatSocket } from "../../socket/socketManager.js";
+import { chatSocket } from "../../socket/socket.js";
 
 const sendChatHandler = (e, type, receiverID = null) => {
   if ((e.key === "Enter" || e.keyCode === 13) && !e.isComposing) {

--- a/frontend/src/handlers/game/gameHandler.js
+++ b/frontend/src/handlers/game/gameHandler.js
@@ -1,4 +1,4 @@
-import { gameSocket } from "../../socket/socketManager.js";
+import { gameSocket } from "../../socket/socket.js";
 import { gameInfoStore } from "../../store/initialStates.js";
 import getRouter from "../../core/router.js";
 

--- a/frontend/src/handlers/game/inviteUserHandler.js
+++ b/frontend/src/handlers/game/inviteUserHandler.js
@@ -1,5 +1,5 @@
 import showToast from "../../utils/showToast.js";
-import { gameSocket } from "../../socket/socketManager.js";
+import { gameSocket } from "../../socket/socket.js";
 
 const inviteUserHandler = (userId) => {
   const { sendSocket } = gameSocket();

--- a/frontend/src/handlers/game/matchMakingHandlers.js
+++ b/frontend/src/handlers/game/matchMakingHandlers.js
@@ -1,4 +1,4 @@
-import { gameSocket } from "../../socket/socketManager.js";
+import { gameSocket } from "../../socket/socket.js";
 import showToast from "../../utils/showToast.js";
 import {
   gameInfoStore,

--- a/frontend/src/pages/LobbyPage.js
+++ b/frontend/src/pages/LobbyPage.js
@@ -6,7 +6,7 @@ import SideBar from "../components/Lobby/SideBar.js";
 import fetchMyInfo from "../api/user/fetchMyInfo.js";
 import showToast from "../utils/showToast.js";
 import getRouter from "../core/router.js";
-import { chatSocket, gameSocket } from "../socket/socketManager.js";
+import { chatSocket, gameSocket } from "../socket/socket.js";
 import fetchFriendList from "../api/user/fetchFriendList.js";
 import fetchBlockList from "../api/user/fetchBlockList.js";
 

--- a/frontend/src/socket/socket.js
+++ b/frontend/src/socket/socket.js
@@ -39,6 +39,7 @@ const initSocket = (path) => {
 
     const clearSocket = () => {
       instance = null;
+      ws.close();
       ws = null;
       observers = {};
     };

--- a/frontend/src/socket/socket.js
+++ b/frontend/src/socket/socket.js
@@ -1,7 +1,7 @@
 const initSocket = (path) => {
   let instance;
   let ws;
-  const observers = {};
+  let observers = {};
 
   const createSocket = () => {
     ws = new WebSocket(`ws://localhost:3000/ws${path}`);
@@ -37,7 +37,13 @@ const initSocket = (path) => {
       ws.send(message);
     };
 
-    return { addSocketObserver, sendSocket };
+    const clearSocket = () => {
+      instance = null;
+      ws = null;
+      observers = {};
+    };
+
+    return { addSocketObserver, sendSocket, clearSocket };
   };
 
   return () => {


### PR DESCRIPTION
로그아웃 시 웹소켓 객체에 대해 close를 호출하여 연결을 명시적으로 해제하고 싱글톤 인스턴스를 null 초기화하여, 재로그인 시 createSocket 함수가 다시 호출될 수 있도록 수정하였습니다.